### PR TITLE
Protect from `*read-default-float-format*`.

### DIFF
--- a/ieee-floats.lisp
+++ b/ieee-floats.lisp
@@ -106,7 +106,7 @@ point numbers anymore, but also keywords."
            (if (zerop exponent)         ; (D)
                (setf exponent 1)
                (setf (ldb (byte 1 ,significand-bits) significand) 1))
-           (let ((float-significand (float significand ,(if (> total-bits 32) 1.0d0 1.0))))
+           (let ((float-significand (float significand ,(if (> total-bits 32) 1.0d0 1.0f0))))
              (scale-float (if (zerop sign) float-significand (- float-significand))
                           (- exponent ,(+ exponent-offset significand-bits))))))))) ; (E)
 


### PR DESCRIPTION
This is a trivial change that protects against what was (for me) a very confusing bug: if `ieee-floats` happens to be compiled while `*read-default-float-format*` is bound to `double-float`, then `decode-float32` ends up returning a double float.