### PR TITLE
Fix system warnings for asdf3

### DIFF
--- a/doc/index.html
+++ b/doc/index.html
@@ -61,11 +61,11 @@ github</a>.</p>
   </code>
 </pre>
 
-<p>Alternatively, you can run tests manually, provided you first load the <tt>ieee-floats-tests</tt> system.</p>
+<p>Alternatively, you can run tests manually, provided you first load the <tt>ieee-floats/tests</tt> system.</p>
 
 <pre>
   <code>
-    CL-USER> (asdf:load-system :ieee-floats-tests)
+    CL-USER> (asdf:load-system :ieee-floats/tests)
     ...
     CL-USER> (fiveam:run! :ieee-floats)
     ..................................................

--- a/ieee-floats.asd
+++ b/ieee-floats.asd
@@ -3,9 +3,9 @@
   :author "Marijn Haverbeke <marijnh@gmail.com>"
   :license "BSD"
   :components ((:file "ieee-floats"))
-  :in-order-to ((test-op (test-op "ieee-floats-tests"))))
+  :in-order-to ((test-op (test-op "ieee-floats/tests"))))
 
-(defsystem :ieee-floats-tests
+(defsystem :ieee-floats/tests
   :description "Test suite for ieee-floats"
   :author "Marijn Haverbeke <marijnh@gmail.com>"
   :license "BSD"

--- a/tests.lisp
+++ b/tests.lisp
@@ -1,9 +1,9 @@
-(defpackage :ieee-floats-tests
+(defpackage :ieee-floats/tests
   (:use :common-lisp
         :ieee-floats
         :fiveam))
 
-(in-package :ieee-floats-tests)
+(in-package :ieee-floats/tests)
 
 ;; After loading, run the tests with (fiveam:run! :ieee-floats)
 


### PR DESCRIPTION
Use a slash instead of a dash in system and package names to avoid asdf3 warnings like the following. Will probably eventually become an error.

```
WARNING: System definition file #P".../ieee-floats/2017-08-30/ieee-floats.asd" contains definition for system "ieee-floats-tests". Please only define "ieee-floats" and secondary systems with a name starting with "ieee-floats/" (e.g. "ieee-floats/test") in that file.
```